### PR TITLE
Fix :Attribute in password.uncompromised

### DIFF
--- a/validation.php
+++ b/validation.php
@@ -117,7 +117,7 @@ return [
         'mixed' => ':Attribute moet minstens één hoofdletter en één kleine letter bevatten.',
         'numbers' => ':Attribute moet minstens één nummer bevatten.',
         'symbols' => ':Attribute moet minstens één symbool bevatten.',
-        'uncompromised' => 'Attribute komt voor in een data lek. Kies een ander :attribute.',
+        'uncompromised' => ':Attribute komt voor in een data lek. Kies een ander :attribute.',
     ],
     'present' => ':Attribute dient aanwezig te zijn.',
     'prohibited' => 'Het :attribute veld is niet toegestaan.',


### PR DESCRIPTION
Currently it doesn't replace `Attribute` with the actual attribute.

before: `Attribute komt voor in een data lek. Kies een ander password.`
after: `Password komt voor in een data lek. Kies een ander password.`